### PR TITLE
Extract HTTP::Connection ala Reel (WIP: DO NOT MERGE)

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -2,6 +2,7 @@ require 'http/parser'
 
 require 'http/chainable'
 require 'http/client'
+require 'http/connection'
 require 'http/options'
 require 'http/request'
 require 'http/request/writer'

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -1,0 +1,107 @@
+require 'http/response/parser'
+
+module HTTP
+  # A connection to the HTTP server
+  class Connection
+    CONNECTION         = 'Connection'.freeze
+    TRANSFER_ENCODING  = 'Transfer-Encoding'.freeze
+    KEEP_ALIVE         = 'Keep-Alive'.freeze
+    CLOSE              = 'close'.freeze
+
+    attr_reader   :socket, :parser, :current_response
+    attr_accessor :request_state, :response_state
+
+    # Attempt to read this much data
+    BUFFER_SIZE = 16384
+    attr_reader :buffer_size
+
+    def initialize(socket, buffer_size = nil)
+      @socket      = socket
+      @keepalive   = true
+      @buffer_size = buffer_size || BUFFER_SIZE
+      @parser      = Response::Parser.new(self)
+
+      @request_state  = :headers
+      @response_state = :headers
+      reset_response
+    end
+
+    # Is the connection still active?
+    def alive?; @keepalive; end
+
+    # Send a request to the server
+    # Response can be a symbol indicating the status code or a HTTP::Response
+    def respond(response, headers_or_body = {}, body = nil)
+      raise StateError, "not in header state" if @response_state != :headers
+
+      if headers_or_body.is_a? Hash
+        headers = headers_or_body
+      else
+        headers = {}
+        body = headers_or_body
+      end
+
+      if @keepalive
+        headers[CONNECTION] = KEEP_ALIVE
+      else
+        headers[CONNECTION] = CLOSE
+      end
+
+      case response
+      when Symbol
+        response = Response.new(response, headers, body)
+      when Response
+      else raise TypeError, "invalid response: #{response.inspect}"
+      end
+
+      if current_request
+        current_request.handle_response(response)
+      else
+        raise RequestError
+      end
+
+      # Enable streaming mode
+      if response.chunked? and response.body.nil?
+        @response_state = :chunked_body
+      elsif @keepalive
+        reset_request
+      else
+        @current_request = nil
+        @parser.reset
+        @request_state = :closed
+      end
+    rescue IOError, Errno::ECONNRESET, Errno::EPIPE, RequestError
+      # The client disconnected early, or there is no request
+      @keepalive = false
+      @request_state = :closed
+    end
+
+    def readpartial(size = @buffer_size)
+      unless @request_state == :headers || @request_state == :body
+        raise StateError, "can't read in the '#{@request_fsm.state}' request state"
+      end
+
+      @parser.readpartial(size)
+    end
+
+    # Close the connection
+    def close
+      @keepalive = false
+      @socket.close unless @socket.closed?
+    end
+
+    # Reset the current response state
+    def reset_response
+      @response_state  = :headers
+      @current_request = nil
+      @parser.reset
+    end
+    private :reset_response
+
+    # Set response state for the connection.
+    def response_state=(state)
+      reset_response if state == :headers
+      @response_state = state
+    end
+  end
+end

--- a/spec/http/connection_spec.rb
+++ b/spec/http/connection_spec.rb
@@ -1,0 +1,474 @@
+require 'spec_helper'
+
+describe HTTP::Connection do
+  let(:fixture_path) { File.expand_path("../../fixtures/example.txt", __FILE__) }
+
+  it "reads responses without bodies" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+      client << ExampleResponse.new.to_s
+      response = connection.current_response
+
+      response.url.should     eq "/"
+      response.version.should eq "1.1"
+
+      response['Host'].should eq "www.example.com"
+      response['Connection'].should eq "keep-alive"
+      response['User-Agent'].should eq "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.78 S"
+      response['Accept'].should eq "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+      response['Accept-Encoding'].should eq "gzip,deflate,sdch"
+      response['Accept-Language'].should eq "en-US,en;q=0.8"
+      response['Accept-Charset'].should eq "ISO-8859-1,utf-8;q=0.7,*;q=0.3"
+    end
+  end
+
+  it "reads responses with bodies" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+      body = "Hello, world!"
+      example_response = ExampleResponse.new
+      example_response.body = body
+
+      client << example_response.to_s
+      response = connection.current_response
+
+      response.url.should     eq "/"
+      response.version.should eq "1.1"
+      response['Content-Length'].should eq body.length.to_s
+      response.body.to_s.should eq example_response.body
+    end
+  end
+
+  it "reads responses with large bodies" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+      client << ExampleResponse.new.to_s
+      response = connection.current_response
+
+      fixture_text = File.read(fixture_path)
+      File.open(fixture_path) do |file|
+        connection.respond :ok, file
+        connection.close
+      end
+
+      response = client.read(4096)
+      response[(response.length - fixture_text.length)..-1].should eq fixture_text
+    end
+  end
+
+  it "enumerates responses with #each_response" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+      client << ExampleResponse.new.to_s
+
+      response_count = 0
+      connection.each_response do |response|
+        response_count += 1
+        response.url.should eq "/"
+        response.respond :ok
+        client.close
+      end
+
+      response_count.should eq 1
+    end
+  end
+
+  context "streams responses when transfer-encoding is chunked" do
+    def test_chunked_response(response, client)
+      # Sending transfer_encoding chunked without a body enables streaming mode
+      response.respond :ok, :transfer_encoding => :chunked
+
+      # This will send individual chunks
+      response << "Hello"
+      response << "World"
+      response.finish_response # Write trailer and reset connection to header mode
+
+      response = ""
+
+      begin
+        while chunk = client.readpartial(4096)
+          response << chunk
+          break if response =~ /0\r\n\r\n$/
+        end
+      rescue EOFError
+      end
+
+      crlf = "\r\n"
+      fixture = "5#{crlf}Hello#{crlf}5#{crlf}World#{crlf}0#{crlf*2}"
+      response[(response.length - fixture.length)..-1].should eq fixture
+    end
+    
+    it "with keep-alive" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        client << ExampleResponse.new.to_s
+        response = connection.current_response
+
+        test_chunked_response(response, client)
+        connection.close
+      end
+    end
+
+    it "without keep-alive" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        client << ExampleResponse.new.tap{ |r|
+          r['Connection'] = 'close'
+        }.to_s
+        response = connection.current_response
+
+        test_chunked_response(response, client)
+        connection.close
+      end
+    end
+
+    it "with pipelined responses" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+
+        2.times do
+          client << ExampleResponse.new.to_s
+        end
+        client << ExampleResponse.new.tap { |r|
+          r['Connection'] = 'close'
+        }.to_s
+
+        3.times do
+          response = connection.current_response
+          test_chunked_response(response, client)
+        end
+        connection.close
+      end
+    end
+  end
+  
+  it "reset the response after a response is sent" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+      example_response = ExampleResponse.new(:get, "/", "1.1", {'Connection' => 'close'})
+      client << example_response
+
+      connection.current_response.should_not be_nil
+
+      connection.respond :ok, "Response sent"
+
+      connection.current_response.should be_nil
+    end
+  end
+
+  it "raises an error trying to read two pipelines without responding first" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+
+      2.times do
+        client << ExampleResponse.new.to_s
+      end
+
+      expect do
+        2.times { response = connection.current_response }
+      end.to raise_error(HTTP::StateError)
+    end
+  end
+
+  it "reads pipelined responses without bodies" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+
+      3.times { client << ExampleResponse.new.to_s }
+
+      3.times do
+        response = connection.current_response
+
+        response.url.should     eq "/"
+        response.version.should eq "1.1"
+
+        response['Host'].should eq "www.example.com"
+        response['Connection'].should eq "keep-alive"
+        response['User-Agent'].should eq "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.78 S"
+        response['Accept'].should eq "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        response['Accept-Encoding'].should eq "gzip,deflate,sdch"
+        response['Accept-Language'].should eq "en-US,en;q=0.8"
+        response['Accept-Charset'].should eq "ISO-8859-1,utf-8;q=0.7,*;q=0.3"
+        connection.respond :ok, {}, ""
+      end
+    end
+  end
+
+  it "reads pipelined responses with bodies" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+
+      3.times do |i|
+        body = "Hello, world number #{i}!"
+        example_response = ExampleResponse.new
+        example_response.body = body
+
+        client << example_response.to_s
+      end
+
+      3.times do |i|
+        response = connection.current_response
+
+        expected_body = "Hello, world number #{i}!"
+        response.url.should     eq "/"
+        response.version.should eq "1.1"
+        response['Content-Length'].should eq expected_body.length.to_s
+        response.body.to_s.should eq expected_body
+
+        connection.respond :ok, {}, ""
+      end
+    end
+  end
+
+  it "reads pipelined responses with streamed bodies" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer, 4)
+
+      3.times do |i|
+        body = "Hello, world number #{i}!"
+        example_response = ExampleResponse.new
+        example_response.body = body
+
+        client << example_response.to_s
+      end
+
+      3.times do |i|
+        response = connection.current_response
+
+        expected_body = "Hello, world number #{i}!"
+        response.url.should     eq "/"
+        response.version.should eq "1.1"
+        response['Content-Length'].should eq expected_body.length.to_s
+        response.should_not be_finished_reading
+        new_content = ""
+        while chunk = response.body.readpartial(1)
+          new_content << chunk
+        end
+        new_content.should == expected_body
+        response.should be_finished_reading
+
+        connection.respond :ok, {}, ""
+      end
+    end
+  end
+
+  # This test will deadlock rspec waiting unless
+  # connection.current_response works properly
+  it "does not block waiting for body to read before handling response" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+      example_response = ExampleResponse.new
+
+      content = "Hi guys! Sorry I'm late to the party."
+      example_response['Content-Length'] = content.length
+      client << example_response.to_s
+
+      response = connection.current_response
+      response.should be_a(HTTP::Response)
+      client << content
+      response.body.to_s.should == content
+    end
+  end
+
+  it "blocks on read until written" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+      example_response = ExampleResponse.new
+
+      content = "Hi guys! Sorry I'm late to the party."
+      example_response['Content-Length'] = content.length
+      client << example_response.to_s
+
+      response = connection.current_response
+      timers = Timers.new
+      timers.after(0.2){
+        client << content
+      }
+      read_body = ""
+      timers.after(0.1){
+        timers.wait # continue timers, the next bit will block waiting for content
+        read_body = response.read(8)
+      }
+      timers.wait
+
+      response.should be_a(HTTP::Response)
+      read_body.should == content[0..7]
+    end
+  end
+
+  it "streams body properly with #read and buffered body" do
+    with_socket_pair do |client, peer|
+      connection = HTTP::Connection.new(peer)
+      example_response = ExampleResponse.new
+
+      content = "I'm data you can stream!"
+      example_response['Content-Length'] = content.length
+      client << example_response.to_s
+
+      response = connection.current_response
+      response.should be_a(HTTP::Response)
+      response.should_not be_finished_reading
+      client << content
+      rebuilt = []
+      connection.readpartial(64) # Buffer some body
+      while chunk = response.read(8)
+        rebuilt << chunk
+      end
+      response.should be_finished_reading
+      rebuilt.should == ["I'm data", " you can", " stream!"]
+    end
+  end
+
+  context "#readpartial" do
+    it "streams response bodies" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer, 8)
+        example_response = ExampleResponse.new
+
+        content = "I'm data you can stream!"
+        example_response['Content-Length'] = content.length
+        client << example_response.to_s
+
+        response = connection.current_response
+        response.should be_a(HTTP::Response)
+        response.should_not be_finished_reading
+        client << content
+        rebuilt = []
+        while chunk = response.body.readpartial(8)
+          rebuilt << chunk
+        end
+        response.should be_finished_reading
+        rebuilt.should == ["I'm data", " you can", " stream!"]
+      end
+    end
+  end
+
+  context "#each" do
+    it "streams response bodies" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        example_response = ExampleResponse.new
+
+        content = "I'm data you can stream!"
+        example_response['Content-Length'] = content.length
+        client << example_response.to_s
+
+        response = connection.current_response
+        response.should be_a(HTTP::Response)
+        response.should_not be_finished_reading
+        client << content
+
+        data = ""
+        response.body.each { |chunk| data << chunk }
+        response.should be_finished_reading
+        data.should == "I'm data you can stream!"
+      end
+    end
+  end
+
+  describe "IO#read duck typing" do
+    it "raises an exception if length is a negative value" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        example_response = ExampleResponse.new
+
+        client << example_response.to_s
+        response = connection.current_response
+
+        lambda { response.read(-1) }.should raise_error(ArgumentError)
+      end
+    end
+
+    it "returns an empty string if the length is zero" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        example_response = ExampleResponse.new
+
+        client << example_response.to_s
+        response = connection.current_response
+
+        response.read(0).should be_empty
+      end
+    end
+
+    it "reads to EOF if length is nil, even small buffer" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer, 4)
+        example_response = ExampleResponse.new
+        example_response.body = "Hello, world!"
+        connection.buffer_size.should == 4
+
+        client << example_response.to_s
+        response = connection.current_response
+
+        response.read.should eq "Hello, world!"
+      end
+    end
+
+    it "reads to EOF if length is nil" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        example_response = ExampleResponse.new
+        example_response.body = "Hello, world!"
+
+
+        client << example_response.to_s
+        response = connection.current_response
+
+        response.read.should eq "Hello, world!"
+      end
+    end
+
+    it "uses the optional buffer to recieve data" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        example_response = ExampleResponse.new
+        example_response.body = "Hello, world!"
+
+        client << example_response.to_s
+        response = connection.current_response
+
+        buffer = ''
+        response.read(nil, buffer).should eq "Hello, world!"
+        buffer.should eq "Hello, world!"
+      end
+    end
+
+    it "returns with the content it could read when the length longer than EOF" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        example_response = ExampleResponse.new
+        example_response.body = "Hello, world!"
+
+        client << example_response.to_s
+        response = connection.current_response
+
+        response.read(1024).should eq "Hello, world!"
+      end
+    end
+
+    it "returns nil at EOF if a length is passed" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        example_response = ExampleResponse.new
+
+        client << example_response.to_s
+        response = connection.current_response
+
+        response.read(1024).should be_nil
+      end
+    end
+
+    it "returns an empty string at EOF if length is nil" do
+      with_socket_pair do |client, peer|
+        connection = HTTP::Connection.new(peer)
+        example_response = ExampleResponse.new
+
+        client << example_response.to_s
+        response = connection.current_response
+
+        response.read.should be_empty
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'simplecov'
 require 'coveralls'
+require 'support/example_response'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,
@@ -31,4 +32,21 @@ def capture_warning
     $stderr = old_stderr
   end
   result
+end
+
+def with_socket_pair
+  host = '127.0.0.1'
+  port = 10101
+
+  server = TCPServer.new(host, port)
+  client = TCPSocket.new(host, port)
+  peer   = server.accept
+
+  begin
+    yield client, peer
+  ensure
+    server.close rescue nil
+    client.close rescue nil
+    peer.close   rescue nil
+  end
 end

--- a/spec/support/example_response.rb
+++ b/spec/support/example_response.rb
@@ -1,0 +1,38 @@
+require 'time'
+require 'forwardable'
+
+class ExampleResponse
+  extend Forwardable
+  def_delegators :@headers, :[], :[]=
+  attr_accessor  :status, :version, :date, :body
+
+  def initialize(status = 200, body_or_headers = nil, body = nil)
+    @status  = status.to_i
+    @version = "1.1"
+    @date    = Time.now.utc.rfc2822
+
+    if body_or_headers.is_a?(Hash)
+      headers = body_or_headers.dup
+      @body   = body.to_s
+    else
+      headers = {}
+      @body   = body_or_headers.to_s
+    end
+
+    @headers = {
+      'Content-Type'  => 'text/html',
+      'Date'          => @date,
+      'Server'        => 'example_response.rb'
+    }.merge(headers)
+  end
+
+  def to_s
+    if body && !@headers['Content-Length']
+      @headers['Content-Length'] = @body.length
+    end
+
+    "HTTP/#{version} #{status} #{HTTP::Response::STATUS_CODES[status]}\r\n" <<
+    @headers.map { |k, v| "#{k}: #{v}" }.join("\r\n") << "\r\n\r\n" <<
+    (body || '')
+  end
+end


### PR DESCRIPTION
This is a work-in-progress commit to structure the connection management and pipelining closer to what is presently used today in Reel.

Much of the code is modified copypasta from Reel. I wish there were a more DRY abstraction for this sort of thing (reusing client/server parts of HTTP libraries) but if it exists it presently escapes me.

As there seems to be a lot of interest in this library as of late, I'm posing my (still nowhere near complete) WIP work for some early review. I wish there were a better way to break this change apart into a series of smaller, more easily reviewable changes, but as this is full blown "catching up to Reel" I'm not sure how that's possible.

Comments strongly encouraged!