### PR TITLE
Use at_exit instead of overriding trap for interrupt to shutdown ProxyServer, AuthenticatedProxyServer

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,23 +19,6 @@ require "support/capture_warning"
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  servers = [
-    ProxyServer,
-    AuthenticatedProxyServer,
-    ExampleServer.instance
-  ]
-  threads = []
-
-  config.before :suite do
-    threads.push(*servers.map { |server| Thread.new { server.start } })
-    # wait until servers fully boot up
-    Thread.pass while threads.any? { |t| t.status && t.status != "sleep" }
-  end
-
-  config.after :suite do
-    servers.each { |server| server.shutdown }
-    threads.each(&:join).clear
-  end
 
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,24 @@ require "support/capture_warning"
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  servers = [
+    ProxyServer,
+    AuthenticatedProxyServer,
+    ExampleServer.instance
+  ]
+  threads = []
+
+  config.before :suite do
+    threads.push(*servers.map { |server| Thread.new { server.start } })
+    # wait until servers fully boot up
+    Thread.pass while threads.any? { |t| t.status && t.status != "sleep" }
+  end
+
+  config.after :suite do
+    servers.each { |server| server.shutdown }
+    threads.each(&:join).clear
+  end
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods

--- a/spec/support/example_server.rb
+++ b/spec/support/example_server.rb
@@ -19,12 +19,3 @@ class ExampleServer
 
   delegate [:start, :shutdown] => :@server
 end
-
-t = Thread.new { ExampleServer.instance.start }
-
-trap("INT") do
-  ExampleServer.instance.shutdown
-  exit
-end
-
-Thread.pass while t.status && t.status != "sleep"

--- a/spec/support/proxy_server.rb
+++ b/spec/support/proxy_server.rb
@@ -17,9 +17,3 @@ AuthenticatedProxyServer = WEBrick::HTTPProxyServer.new(
   end,
   :RequestCallback => handler
 )
-
-Thread.new { ProxyServer.start }
-at_exit { ProxyServer.shutdown }
-
-Thread.new { AuthenticatedProxyServer.start }
-at_exit { AuthenticatedProxyServer.shutdown }

--- a/spec/support/proxy_server.rb
+++ b/spec/support/proxy_server.rb
@@ -1,38 +1,38 @@
+require "support/black_hole"
 require "webrick/httpproxy"
 
-handler = proc { |_, res| res["X-PROXIED"] = true }
+def with_proxy(port, handler, options = {})
+  proxy = WEBrick::HTTPProxyServer.new({
+    :Port => port,
+    :AccessLog => [],
+    :ProxyContentHandler => handler,
+    :Logger => BlackHole
+  }.merge(options))
 
-ProxyServer = WEBrick::HTTPProxyServer.new(
-  :Port => 8080,
-  :AccessLog => [],
-  :RequestCallback => handler
-)
+  oversee_webrick_server(proxy) { yield proxy }
+end
 
-AuthenticatedProxyServer = WEBrick::HTTPProxyServer.new(
-  :Port => 8081,
-  :ProxyAuthProc => proc do | req, res |
-    WEBrick::HTTPAuth.proxy_basic_auth(req, res, "proxy") do | user, pass |
-      user == "username" && pass == "password"
+def with_auth_proxy(port, handler, options = {})
+  username = options.fetch(:user)
+  password = options.fetch(:password)
+
+  auth_proc = proc do | req, res |
+    WEBrick::HTTPAuth.proxy_basic_auth(req, res, "proxy") do |user, pass|
+      user == username && pass == password
     end
-  end,
-  :RequestCallback => handler
-)
-
-RSpec.configure do |config|
-  servers = [
-    ProxyServer,
-    AuthenticatedProxyServer
-  ]
-  threads = []
-
-  config.before :suite do
-    threads.push(*servers.map { |server| Thread.new { server.start } })
-    # wait until servers fully boot up
-    Thread.pass while threads.any? { |t| t.status && t.status != "sleep" }
   end
 
-  config.after :suite do
-    servers.each { |server| server.shutdown }
-    threads.each(&:join).clear
+  with_proxy(port, handler, options.merge(:ProxyAuthProc => auth_proc)) { |proxy| yield proxy }
+end
+
+def oversee_webrick_server(server)
+  thread = Thread.new { server.start }
+  Thread.pass while thread.status != "sleep"
+
+  begin
+    yield server
+  ensure
+    server.shutdown
+    thread.join
   end
 end

--- a/spec/support/proxy_server.rb
+++ b/spec/support/proxy_server.rb
@@ -18,14 +18,8 @@ AuthenticatedProxyServer = WEBrick::HTTPProxyServer.new(
   :RequestCallback => handler
 )
 
-Thread.new  { ProxyServer.start }
-trap("INT") do
-  ProxyServer.shutdown
-  exit
-end
+Thread.new { ProxyServer.start }
+at_exit { ProxyServer.shutdown }
 
-Thread.new  { AuthenticatedProxyServer.start }
-trap("INT") do
-  AuthenticatedProxyServer.shutdown
-  exit
-end
+Thread.new { AuthenticatedProxyServer.start }
+at_exit { AuthenticatedProxyServer.shutdown }


### PR DESCRIPTION

Call to trap replaces handler for specified signal,
so ProxyServer.shutdown would have never been called.
at_exit registers handler for execution when the programm
exits, handlers are executed in revers order of registration.