### PR TITLE
Ensure we verify SSL certificate identify after connecting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   CountComments: false
-  Max: 100
+  Max: 110
 
 Metrics/CyclomaticComplexity:
   Max: 8 # TODO: Lower to 6

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :test do
   gem "rspec-its"
   gem "rubocop"
   gem "yardstick"
+  gem "certificate_authority"
 end
 
 group :doc do

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -58,7 +58,7 @@ module HTTP
 
       # TODO: keep-alive support
       @socket = options[:socket_class].open(req.socket_host, req.socket_port)
-      @socket = start_tls(@socket, options) if uri.is_a?(URI::HTTPS) && !req.using_proxy?
+      @socket = start_tls(@socket, uri.host, options) if uri.is_a?(URI::HTTPS) && !req.using_proxy?
 
       req.stream @socket
 
@@ -96,12 +96,17 @@ module HTTP
     private
 
     # Initialize TLS connection
-    def start_tls(socket, options)
+    def start_tls(socket, host, options)
       # TODO: abstract away SSLContexts so we can use other TLS libraries
       context = options[:ssl_context] || OpenSSL::SSL::SSLContext.new
       socket  = options[:ssl_socket_class].new(socket, context)
 
       socket.connect
+
+      if context.verify_mode == OpenSSL::SSL::VERIFY_PEER
+        socket.post_connection_check(host)
+      end
+
       socket
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,13 @@ require "http"
 require "rspec/its"
 require "support/capture_warning"
 
+# Allow testing against a SSL server
+def certs_dir
+  Pathname.new File.expand_path("../../tmp/certs", __FILE__)
+end
+
+require "support/create_certs"
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/support/create_certs.rb
+++ b/spec/support/create_certs.rb
@@ -1,0 +1,57 @@
+require "fileutils"
+require "certificate_authority"
+
+FileUtils.mkdir_p(certs_dir)
+
+#
+# Certificate Authority
+#
+
+ca = CertificateAuthority::Certificate.new
+
+ca.subject.common_name  = "honestachmed.com"
+ca.serial_number.number = 1
+ca.key_material.generate_key
+ca.signing_entity = true
+
+ca.sign! "extensions" => {"keyUsage" => {"usage" => %w(critical keyCertSign)}}
+
+ca_cert_path = File.join(certs_dir, "ca.crt")
+ca_key_path  = File.join(certs_dir, "ca.key")
+
+File.write ca_cert_path, ca.to_pem
+File.write ca_key_path,  ca.key_material.private_key.to_pem
+
+#
+# Server Certificate
+#
+
+server_cert = CertificateAuthority::Certificate.new
+server_cert.subject.common_name  = "127.0.0.1"
+server_cert.serial_number.number = 1
+server_cert.key_material.generate_key
+server_cert.parent = ca
+server_cert.sign!
+
+server_cert_path = File.join(certs_dir, "server.crt")
+server_key_path  = File.join(certs_dir, "server.key")
+
+File.write server_cert_path, server_cert.to_pem
+File.write server_key_path,  server_cert.key_material.private_key.to_pem
+
+#
+# Client Certificate
+#
+
+client_cert = CertificateAuthority::Certificate.new
+client_cert.subject.common_name  = "127.0.0.1"
+client_cert.serial_number.number = 1
+client_cert.key_material.generate_key
+client_cert.parent = ca
+client_cert.sign!
+
+client_cert_path = File.join(certs_dir, "client.crt")
+client_key_path  = File.join(certs_dir, "client.key")
+
+File.write client_cert_path, client_cert.to_pem
+File.write client_key_path,  client_cert.key_material.private_key.to_pem

--- a/spec/support/dummy_server.rb
+++ b/spec/support/dummy_server.rb
@@ -1,4 +1,5 @@
 require "webrick"
+require "webrick/ssl"
 
 require "support/black_hole"
 require "support/dummy_server/servlet"
@@ -15,12 +16,37 @@ class DummyServer < WEBrick::HTTPServer
     :Logger       => BlackHole
   }.freeze
 
-  def initialize
-    super CONFIG
+  def initialize(options = {})
+    if options[:ssl]
+      override_config = {
+        :SSLEnable            => true,
+        :SSLStartImmediately  => true
+      }
+    else
+      override_config = {}
+    end
+
+    super CONFIG.merge(override_config)
+
     mount("/", Servlet)
   end
 
   def endpoint
-    "http://#{addr}:#{port}"
+    "#{ssl? ? 'https' : 'http'}://#{addr}:#{port}"
+  end
+
+  def ssl_context
+    @ssl_context ||= begin
+      context = OpenSSL::SSL::SSLContext.new
+      context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      context.key = OpenSSL::PKey::RSA.new(
+        File.read(File.join(certs_dir, "server.key"))
+      )
+      context.cert = OpenSSL::X509::Certificate.new(
+        File.read(File.join(certs_dir, "server.crt"))
+      )
+      context.ca_file = File.join(certs_dir, "ca.crt")
+      context
+    end
   end
 end

--- a/spec/support/servers/config.rb
+++ b/spec/support/servers/config.rb
@@ -1,4 +1,8 @@
 module ServerConfig
+  def ssl?
+    !!config[:SSLEnable]
+  end
+
   def addr
     config[:BindAddress]
   end


### PR DESCRIPTION
Right now http.rb doesn't run the post certificate check after connecting, meaning a mismatch host doesn't raise an error like it normally would.

cc @tarcieri 