### PR TITLE
Set sync_close when available to avoid leaking sockets

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -100,6 +100,7 @@ module HTTP
       # TODO: abstract away SSLContexts so we can use other TLS libraries
       context = options[:ssl_context] || OpenSSL::SSL::SSLContext.new
       socket  = options[:ssl_socket_class].new(socket, context)
+      socket.sync_close = true if socket.respond_to?(:sync_close=)
 
       socket.connect
 


### PR DESCRIPTION
Since `SSLSocket` wraps a socket, when you call `close` you're calling `socket.flush` (on SSLSocket) and then `socket.sysclose` which goes to https://www.omniref.com/ruby/1.9.3.484/symbols/OpenSSL::SSL::SSLSocket/sysclose. That will free up all the SSL bits, but it doesn't close the underlying socket that was passed to SSLSocket. Adding `sync_close` will make sure that it actually does that to avoid leaks.