### PR TITLE
Backport #180 (CVE-2015-1828) in 0-6-stable branch

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ MethodLength:
 
 ClassLength:
   CountComments: false
-  Max: 100
+  Max: 110
 
 CyclomaticComplexity:
   Max: 13 # TODO: lower to 6

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :test do
   gem 'simplecov', '>= 0.9'
   gem 'yardstick'
   gem 'certificate_authority'
+  gem 'activemodel', '~> 3.0'
 end
 
 # Specify your gem's dependencies in http.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test do
   gem 'rubocop', '~> 0.24.0', :platforms => [:ruby_19, :ruby_20, :ruby_21]
   gem 'simplecov', '>= 0.9'
   gem 'yardstick'
+  gem 'certificate_authority'
 end
 
 # Specify your gem's dependencies in http.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
   gem 'yardstick'
   gem 'certificate_authority'
   gem 'activemodel', '~> 3.0'
+  gem 'i18n', '~> 0.6.0'
 end
 
 # Specify your gem's dependencies in http.gemspec

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -51,7 +51,7 @@ module HTTP
 
       # TODO: keep-alive support
       @socket = options[:socket_class].open(req.socket_host, req.socket_port)
-      @socket = start_tls(@socket, options) if uri.is_a?(URI::HTTPS)
+      @socket = start_tls(@socket, uri.host, options) if uri.is_a?(URI::HTTPS)
 
       req.stream @socket
 
@@ -86,12 +86,17 @@ module HTTP
   private
 
     # Initialize TLS connection
-    def start_tls(socket, options)
+    def start_tls(socket, host, options)
       # TODO: abstract away SSLContexts so we can use other TLS libraries
       context = options[:ssl_context] || OpenSSL::SSL::SSLContext.new
       socket  = options[:ssl_socket_class].new(socket, context)
 
       socket.connect
+
+      if context.verify_mode == OpenSSL::SSL::VERIFY_PEER
+        socket.post_connection_check(host)
+      end
+
       socket
     end
 

--- a/spec/http/client_spec.rb
+++ b/spec/http/client_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
+require 'support/dummy_server'
 
 describe HTTP::Client do
   let(:test_endpoint) { "http://127.0.0.1:#{ExampleService::PORT}" }
+  run_server(:dummy_ssl) { DummyServer.new(:ssl => true) }
 
   StubbedClient = Class.new(HTTP::Client) do
     def perform(request, options)
@@ -140,6 +142,38 @@ describe HTTP::Client do
         end
 
         client.request(:get, 'http://example.com/')
+      end
+    end
+  end
+
+  describe 'SSL' do
+    let(:client) do
+      described_class.new(
+        :ssl_context => OpenSSL::SSL::SSLContext.new.tap do |context|
+          context.options = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options]
+
+          context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          context.ca_file = File.join(certs_dir, 'ca.crt')
+          context.cert = OpenSSL::X509::Certificate.new(
+            File.read(File.join(certs_dir, 'client.crt'))
+          )
+          context.key = OpenSSL::PKey::RSA.new(
+            File.read(File.join(certs_dir, 'client.key'))
+          )
+          context
+        end
+      )
+    end
+
+    it 'works via SSL' do
+      response = client.get(dummy_ssl.endpoint)
+      expect(response.body.to_s).to eq('<!doctype html>')
+    end
+
+    context 'with a mismatch host' do
+      it 'errors' do
+        expect { client.get(dummy_ssl.endpoint.gsub('127.0.0.1', 'localhost')) }
+          .to raise_error(OpenSSL::SSL::SSLError, /does not match/)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,13 @@ require 'http'
 require 'support/example_server'
 require 'support/proxy_server'
 
+# Allow testing against a SSL server
+def certs_dir
+  Pathname.new File.expand_path('../../tmp/certs', __FILE__)
+end
+
+require 'support/create_certs'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/black_hole.rb
+++ b/spec/support/black_hole.rb
@@ -1,0 +1,5 @@
+module BlackHole
+  def self.method_missing(*)
+    self
+  end
+end

--- a/spec/support/create_certs.rb
+++ b/spec/support/create_certs.rb
@@ -1,0 +1,57 @@
+require "fileutils"
+require "certificate_authority"
+
+FileUtils.mkdir_p(certs_dir)
+
+#
+# Certificate Authority
+#
+
+ca = CertificateAuthority::Certificate.new
+
+ca.subject.common_name  = "honestachmed.com"
+ca.serial_number.number = 1
+ca.key_material.generate_key
+ca.signing_entity = true
+
+ca.sign! "extensions" => {"keyUsage" => {"usage" => %w(critical keyCertSign)}}
+
+ca_cert_path = File.join(certs_dir, "ca.crt")
+ca_key_path  = File.join(certs_dir, "ca.key")
+
+File.write ca_cert_path, ca.to_pem
+File.write ca_key_path,  ca.key_material.private_key.to_pem
+
+#
+# Server Certificate
+#
+
+server_cert = CertificateAuthority::Certificate.new
+server_cert.subject.common_name  = "127.0.0.1"
+server_cert.serial_number.number = 1
+server_cert.key_material.generate_key
+server_cert.parent = ca
+server_cert.sign!
+
+server_cert_path = File.join(certs_dir, "server.crt")
+server_key_path  = File.join(certs_dir, "server.key")
+
+File.write server_cert_path, server_cert.to_pem
+File.write server_key_path,  server_cert.key_material.private_key.to_pem
+
+#
+# Client Certificate
+#
+
+client_cert = CertificateAuthority::Certificate.new
+client_cert.subject.common_name  = "127.0.0.1"
+client_cert.serial_number.number = 1
+client_cert.key_material.generate_key
+client_cert.parent = ca
+client_cert.sign!
+
+client_cert_path = File.join(certs_dir, "client.crt")
+client_key_path  = File.join(certs_dir, "client.key")
+
+File.write client_cert_path, client_cert.to_pem
+File.write client_key_path,  client_cert.key_material.private_key.to_pem

--- a/spec/support/dummy_server.rb
+++ b/spec/support/dummy_server.rb
@@ -1,0 +1,52 @@
+require "webrick"
+require "webrick/ssl"
+
+require "support/black_hole"
+require "support/dummy_server/servlet"
+require "support/servers/config"
+require "support/servers/runner"
+
+class DummyServer < WEBrick::HTTPServer
+  include ServerConfig
+
+  CONFIG = {
+    :BindAddress  => "127.0.0.1",
+    :Port         => 0,
+    :AccessLog    => BlackHole,
+    :Logger       => BlackHole
+  }.freeze
+
+  def initialize(options = {})
+    if options[:ssl]
+      override_config = {
+        :SSLEnable            => true,
+        :SSLStartImmediately  => true
+      }
+    else
+      override_config = {}
+    end
+
+    super CONFIG.merge(override_config)
+
+    mount("/", Servlet)
+  end
+
+  def endpoint
+    "#{ssl? ? 'https' : 'http'}://#{addr}:#{port}"
+  end
+
+  def ssl_context
+    @ssl_context ||= begin
+      context = OpenSSL::SSL::SSLContext.new
+      context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      context.key = OpenSSL::PKey::RSA.new(
+        File.read(File.join(certs_dir, "server.key"))
+      )
+      context.cert = OpenSSL::X509::Certificate.new(
+        File.read(File.join(certs_dir, "server.crt"))
+      )
+      context.ca_file = File.join(certs_dir, "ca.crt")
+      context
+    end
+  end
+end

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -1,0 +1,30 @@
+class DummyServer < WEBrick::HTTPServer
+  class Servlet < WEBrick::HTTPServlet::AbstractServlet
+    def not_found(_req, res)
+      res.status = 404
+      res.body   = "Not Found"
+    end
+
+    def self.handlers
+      @handlers ||= {}
+    end
+
+    %w(get post head).each do |method|
+      class_eval <<-RUBY, __FILE__, __LINE__
+        def self.#{method}(path, &block)
+          handlers["#{method}:\#{path}"] = block
+        end
+        def do_#{method.upcase}(req, res)
+          handler = self.class.handlers["#{method}:\#{req.path}"]
+          return instance_exec(req, res, &handler) if handler
+          not_found
+        end
+      RUBY
+    end
+
+    get "/" do |req, res|
+      res.status = 200
+      res.body   = "<!doctype html>"
+    end
+  end
+end

--- a/spec/support/servers/config.rb
+++ b/spec/support/servers/config.rb
@@ -1,0 +1,13 @@
+module ServerConfig
+  def ssl?
+    !!config[:SSLEnable]
+  end
+
+  def addr
+    config[:BindAddress]
+  end
+
+  def port
+    config[:Port]
+  end
+end

--- a/spec/support/servers/runner.rb
+++ b/spec/support/servers/runner.rb
@@ -1,0 +1,17 @@
+module ServerRunner
+  def run_server(name, &block)
+    let! name do
+      server = block.call
+
+      Thread.new { server.start }
+
+      server
+    end
+
+    after do
+      send(name).shutdown
+    end
+  end
+end
+
+RSpec.configure { |c| c.extend ServerRunner }


### PR DESCRIPTION
Here is a very naive backport of @zanker's SSL host verification. I would like to have this in a 0.6.x version then add this patched version to https://github.com/rubysec/ruby-advisory-db/blob/master/gems/http/CVE-2015-1828.yml too.

Tell me if I can do anything else about this.