### PR TITLE
First attempt at supporting https connections through proxy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   CountComments: false
-  Max: 110
+  Max: 120
 
 Metrics/PerceivedComplexity:
   Max: 8

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -64,8 +64,11 @@ module HTTP
       @state = :dirty
 
       @connection ||= HTTP::Connection.new(req, options)
-      @connection.send_request(req)
-      @connection.read_headers!
+
+      unless @connection.failed_proxy_connect?
+        @connection.send_request(req)
+        @connection.read_headers!
+      end
 
       res = Response.new(
         @connection.status_code,

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -29,6 +29,12 @@ module HTTP
         send_request_body
       end
 
+      # Send headers needed to connect through proxy
+      def connect_through_proxy
+        add_headers
+        @socket << join_headers
+      end
+
       # Adds the headers to the header array for the given request body we are working
       # with
       def add_body_type_headers
@@ -50,9 +56,8 @@ module HTTP
       def send_request_header
         add_headers
         add_body_type_headers
-        header = join_headers
 
-        @socket << header
+        @socket << join_headers
       end
 
       def send_request_body


### PR DESCRIPTION
This is pretty rough but I wanted to see if this looks like I'm at all going in the right direction. I added a failing test which now passes, so I think this is at least functional. Any feedback on what I need to do to get this into a mergable state would be great.

Connecting to https servers through a http proxy requires sending a CONNECT request to the proxy to setup a tunnel, then performing a normal https request through that tunnel. This PR adds the code to send that CONNECT request before continuing with the normal request.

