### PR TITLE
Alias HTTP::Chainable#persistent to #open

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -78,6 +78,7 @@ module HTTP
     def persistent(host)
       branch default_options.with_persistent host
     end
+    alias_method :open, :persistent
 
     # Make a request through an HTTP proxy
     # @param [Array] proxy

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -74,6 +74,7 @@ module HTTP
     def persistent?
       !persistent.nil? && persistent != ""
     end
+    alias_method :open?, :persistent?
 
     def [](option)
       send(option) rescue nil


### PR DESCRIPTION
Also, alias `HTTP::Options#persistent?` to `#open?`.

Idea came out of the discussion in https://github.com/httprb/http.rb/pull/188.

We can discuss it further here.