### PR TITLE
Fixed tests to avoid mixed responses with Keep Alive

### DIFF
--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -13,13 +13,10 @@ module HTTP
         @client       = client
         @streaming    = nil
         @contents     = nil
-        @active_seq   = client.sequence_id
       end
 
       # (see HTTP::Client#readpartial)
       def readpartial(*args)
-        check_sequence!
-
         stream!
         @client.readpartial(*args)
       end
@@ -36,7 +33,6 @@ module HTTP
         return @contents if @contents
 
         fail StateError, "body is being streamed" unless @streaming.nil?
-        check_sequence!
 
         begin
           @streaming = false
@@ -52,14 +48,6 @@ module HTTP
         @contents
       end
       alias_method :to_str, :to_s
-
-      def check_sequence!
-        return unless @active_seq != @client.sequence_id
-
-        fail StateError, "Sequence ID #{@active_seq} does not match #{@client.sequence_id}. You must read the entire request off."
-      end
-
-      private :check_sequence!
 
       # Assert that the body is actively being streamed
       def stream!

--- a/spec/support/connection_reuse_shared.rb
+++ b/spec/support/connection_reuse_shared.rb
@@ -23,14 +23,8 @@ RSpec.shared_context "handles shared connections" do
 
       context "when trying to read a stale body" do
         it "errors" do
-          first_res = client.get(server.endpoint)
-          second_res = client.get(server.endpoint)
-
-          # This should work, because it's the last request we made
-          expect(second_res.body.to_s).to eq("<!doctype html>")
-
-          # This should not work because we've not read anything
-          expect { first_res.body.to_s }.to raise_error(HTTP::StateError, /Sequence ID 1 does not match 2/i)
+          client.get("#{server.endpoint}/not-found")
+          expect { client.get(server.endpoint) }.to raise_error(HTTP::StateError, /Tried to send a request/)
         end
       end
 
@@ -43,19 +37,6 @@ RSpec.shared_context "handles shared connections" do
 
           expect(first_res.body.to_s).to eq("<!doctype html>")
           expect(second_res.body.to_s).to eq("<!doctype html>")
-        end
-      end
-
-      context "when streaming" do
-        it "errors with a stale response" do
-          first_res = client.get(server.endpoint)
-          second_res = client.get(server.endpoint)
-
-          # This should work, because it's the last request we made
-          expect(second_res.body.to_s).to eq("<!doctype html>")
-
-          # This should not work because we've not read anything
-          expect { first_res.body.each(&:to_s) }.to raise_error(HTTP::StateError, /Sequence ID 1 does not match 2/i)
         end
       end
 


### PR DESCRIPTION
Fun one that was due to a typo :(

The sequence IDs are unnecessary, because in real conditions if you try and request while it's still pending a response it will just simply error.