### PR TITLE
Added Keep-Alive timeouts to auto reset connections

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -94,7 +94,7 @@ module HTTP
 
       # We re-create the connection object because we want to let prior requests
       # lazily load the body as long as possible, and this mimics prior functionality.
-      elsif !default_options.persistent? || (@connection && !@connection.keep_alive?)
+      elsif @connection && (!@connection.keep_alive? || @connection.expired?)
         close
       end
     end

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -44,6 +44,7 @@ module HTTP
                   :socket_class =>     self.class.default_socket_class,
                   :ssl_socket_class => self.class.default_ssl_socket_class,
                   :cache =>            self.class.default_cache,
+                  :keep_alive_timeout  => 5,
                   :headers =>          {}}
 
       opts_w_defaults = defaults.merge(options)
@@ -58,7 +59,11 @@ module HTTP
       self.headers.merge(headers)
     end
 
-    %w(proxy params form json body follow response socket_class ssl_socket_class ssl_context persistent).each do |method_name|
+    %w(
+      proxy params form json body follow response
+      socket_class ssl_socket_class ssl_context
+      persistent keep_alive_timeout
+    ).each do |method_name|
       def_option method_name
     end
 

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -169,16 +169,25 @@ RSpec.describe HTTP::Client do
 
   include_context "handles shared connections" do
     let(:reuse_conn) { nil }
+    let(:keep_alive_timeout) { 5 }
+
     let(:server) { dummy }
-    let(:client) { described_class.new(:persistent => reuse_conn) }
+    let(:client) do
+      described_class.new(
+        :persistent => reuse_conn,
+        :keep_alive_timeout => keep_alive_timeout
+      )
+    end
   end
 
   describe "SSL" do
     let(:reuse_conn) { nil }
+    let(:keep_alive_timeout) { 5 }
 
     let(:client) do
       described_class.new(
         :persistent => reuse_conn,
+        :keep_alive_timeout => keep_alive_timeout,
         :ssl_context => OpenSSL::SSL::SSLContext.new.tap do |context|
           context.options = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options]
 

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe HTTP::Options, "merge" do
       :form      => {:bar => "bar"},
       :body      => "body-bar",
       :json      => {:bar => "bar"},
+      :keep_alive_timeout => 10,
       :headers   => {:accept  => "xml", :bar => "bar"},
       :proxy     => {:proxy_address => "127.0.0.1", :proxy_port => 8080})
 
@@ -42,6 +43,7 @@ RSpec.describe HTTP::Options, "merge" do
       :body      => "body-bar",
       :json      => {:bar => "bar"},
       :persistent  => "https://www.googe.com",
+      :keep_alive_timeout => 10,
       :headers   => {"Foo" => "foo", "Accept"  => "xml", "Bar" => "bar"},
       :proxy     => {:proxy_address => "127.0.0.1", :proxy_port => 8080},
       :follow => nil,

--- a/spec/support/connection_reuse_shared.rb
+++ b/spec/support/connection_reuse_shared.rb
@@ -62,6 +62,18 @@ RSpec.shared_context "handles shared connections" do
         end
       end
 
+      context "with a Keep-Alive timeout of 0" do
+        let(:keep_alive_timeout) { 0 }
+
+        it "automatically opens a new socket" do
+          first_socket = client.get("#{server.endpoint}/socket/1").body.to_s
+          sleep 0.1
+          second_socket = client.get("#{server.endpoint}/socket/2").body.to_s
+
+          expect(first_socket).to_not eq(second_socket)
+        end
+      end
+
       context "with a change in host" do
         it "errors" do
           expect { client.get("https://invalid.com/socket") }.to raise_error(/Persistence is enabled/i)


### PR DESCRIPTION
This is in net-http-persistent too and as far as I can tell it's kind of necessary.

Adds a timeout so if the connection isn't used for more than X seconds, it automatically restarts it.