### PR TITLE
Added SSL config via the ssl param instead of requiring context passing

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -22,7 +22,7 @@ module HTTP
       @socket.start_tls(
         req.uri.host,
         options[:ssl_socket_class],
-        options[:ssl_context]
+        options[:ssl_context] || setup_ssl_context(options[:ssl])
       ) if req.uri.is_a?(URI::HTTPS) && !req.using_proxy?
 
       reset_timer
@@ -139,5 +139,14 @@ module HTTP
     end
 
     private :read_more
+
+    # Sets up a SSL context
+    def setup_ssl_context(params)
+      ssl_context = OpenSSL::SSL::SSLContext.new
+      ssl_context.set_params(params) if params
+      ssl_context
+    end
+
+    private :setup_ssl_context
   end
 end

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -47,6 +47,7 @@ module HTTP
                   :timeout_options =>  {},
                   :socket_class =>     self.class.default_socket_class,
                   :ssl_socket_class => self.class.default_ssl_socket_class,
+                  :ssl =>              {},
                   :cache =>            self.class.default_cache,
                   :keep_alive_timeout  => 5,
                   :headers =>          {}}
@@ -65,7 +66,7 @@ module HTTP
 
     %w(
       proxy params form json body follow response
-      socket_class ssl_socket_class ssl_context
+      socket_class ssl_socket_class ssl_context ssl
       persistent keep_alive_timeout timeout_class timeout_options
     ).each do |method_name|
       def_option method_name

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -25,8 +25,6 @@ module HTTP
 
       # Configures the SSL connection and starts the connection
       def start_tls(host, ssl_socket_class, ssl_context)
-        # TODO: abstract away SSLContexts so we can use other TLS libraries
-        ssl_context ||= OpenSSL::SSL::SSLContext.new
         @socket = ssl_socket_class.new(socket, ssl_context)
         socket.sync_close = true
 

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -194,6 +194,17 @@ RSpec.describe HTTP::Client do
       expect { client.get(dummy_ssl.endpoint.gsub("127.0.0.1", "localhost")) }
         .to raise_error(OpenSSL::SSL::SSLError, /does not match/)
     end
+
+    context "with SSL options instead of a context" do
+      let(:client) do
+        described_class.new options.merge :ssl => SSLHelper.client_params
+      end
+
+      it "just works" do
+        response = client.get(dummy_ssl.endpoint)
+        expect(response.body.to_s).to eq("<!doctype html>")
+      end
+    end
   end
 
   describe "#perform" do

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe HTTP::Options, "merge" do
       :keep_alive_timeout => 10,
       :headers   => {:accept  => "xml", :bar => "bar"},
       :timeout_options => {:foo => :bar},
+      :ssl       => {:foo => "bar"},
       :proxy     => {:proxy_address => "127.0.0.1", :proxy_port => 8080})
 
     expect(foo.merge(bar).to_hash).to eq(
@@ -47,6 +48,7 @@ RSpec.describe HTTP::Options, "merge" do
       :json      => {:bar => "bar"},
       :persistent  => "https://www.googe.com",
       :keep_alive_timeout => 10,
+      :ssl       => {:foo => "bar"},
       :headers   => {"Foo" => "foo", "Accept"  => "xml", "Bar" => "bar"},
       :proxy     => {:proxy_address => "127.0.0.1", :proxy_port => 8080},
       :follow => nil,

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -79,6 +79,14 @@ module SSLHelper
       context
     end
 
+    def client_params
+      {
+        :key => client_cert.key,
+        :cert => client_cert.cert,
+        :ca_file => ca.file
+      }
+    end
+
     %w(server client).each do |side|
       class_eval <<-RUBY, __FILE__, __LINE__
         def #{side}_cert


### PR DESCRIPTION
Makes it a bit easier to configure things for SSL. As an advantage, this gives people more secure SSL configuration by default via the `DEFAULT_PARAMS` in https://github.com/ruby/openssl/blob/master/lib/openssl/ssl.rb#L25.

Personally, I'm not sure how much sense allowing `ssl_context` makes, since I wasn't aware there was really competition for other SSL gems in Ruby. Although I defer to @tarcieri on that.