### PR TITLE
Include JRuby 1.7 as a supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.2
   - jruby
   - jruby-head
+  - jruby-19mode
   - ruby-head
   - rbx-2
 matrix:

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ versions:
 * Ruby 2.0.0
 * Ruby 2.1.x
 * Ruby 2.2.x
+* JRuby 1.7.x
 
 If something doesn't work on one of these versions, it's a bug.
 


### PR DESCRIPTION
Thoughts? I'm going to end up having to maintain this for JRuby incidentally anyway, so might as well include it as an officially supported language.