### PR TITLE
Add an extra set of state tracking for Timeout.timeout edge cases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ Metrics/ClassLength:
   CountComments: false
   Max: 110
 
+Metrics/PerceivedComplexity:
+  Max: 8
+
 Metrics/CyclomaticComplexity:
   Max: 8 # TODO: Lower to 6
 

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -19,6 +19,7 @@ module HTTP
     def initialize(default_options = {})
       @default_options = HTTP::Options.new(default_options)
       @connection = nil
+      @state = :clean
     end
 
     # Make an HTTP request
@@ -58,6 +59,8 @@ module HTTP
     def make_request(req, options)
       verify_connection!(req.uri)
 
+      @state = :dirty
+
       @connection ||= HTTP::Connection.new(req, options)
       @connection.send_request(req)
       @connection.read_headers!
@@ -71,6 +74,7 @@ module HTTP
       )
 
       @connection.finish_response if req.verb == :head
+      @state = :clean
 
       res
 
@@ -85,6 +89,7 @@ module HTTP
     def close
       @connection.close if @connection
       @connection = nil
+      @state = :clean
     end
 
     private
@@ -93,10 +98,13 @@ module HTTP
     def verify_connection!(uri)
       if default_options.persistent? && base_host(uri) != default_options.persistent
         fail StateError, "Persistence is enabled for #{default_options.persistent}, but we got #{base_host(uri)}"
-
       # We re-create the connection object because we want to let prior requests
       # lazily load the body as long as possible, and this mimics prior functionality.
       elsif @connection && (!@connection.keep_alive? || @connection.expired?)
+        close
+      # If we get into a bad state (eg, Timeout.timeout ensure being killed)
+      # close the connection to prevent potential for mixed responses.
+      elsif @state == :dirty
         close
       end
     end


### PR DESCRIPTION
Thoughts? This isn't strictly necessary, as the chance of this happening is very very small. It is still a chance though.

Normally, `Timeout.timeout` raises an exception and kills the block and everything is handy dandy. In rare situations, it will raise and then kill execution while the `rescue` block executes (see https://github.com/mperham/connection_pool/pull/67 for more info).

This adds an extra layer of protection, where if we run into that, we reset the connection anyway.