### PR TITLE
Use Timeout.timeout for TCP connection

### DIFF
--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -1,6 +1,3 @@
-# rubocop:disable Lint/HandleExceptions
-require "resolv"
-
 module HTTP
   module Timeout
     class PerOperation < Null
@@ -20,39 +17,21 @@ module HTTP
         @connect_timeout = options.fetch(:connect_timeout, CONNECT_TIMEOUT)
       end
 
-      def connect(_, host, port)
-        # https://github.com/celluloid/celluloid-io/blob/master/lib/celluloid/io/tcp_socket.rb
-        begin
-          addr = Resolv::IPv4.create(host)
-        rescue ArgumentError
+      def connect(socket_class, host, port)
+        ::Timeout.timeout(connect_timeout, TimeoutError) do
+          @socket = socket_class.open(host, port)
         end
-
-        # Guess it's not IPv4! Is it IPv6?
-        begin
-          addr ||= Resolv::IPv6.create(host)
-        rescue ArgumentError
-        end
-
-        unless addr
-          addr = resolve_address(host)
-          fail Resolv::ResolvError, "DNS result has no information for #{host}" unless addr
-        end
-
-        case addr
-        when Resolv::IPv4
-          family = Socket::AF_INET
-        when Resolv::IPv6
-          family = Socket::AF_INET6
-        else fail ArgumentError, "unsupported address class: #{addr.class}"
-        end
-
-        @socket = Socket.new(family, Socket::SOCK_STREAM, 0)
-
-        connect_with_timeout(Socket.sockaddr_in(port, addr.to_s))
       end
 
-      # No changes need to be made for the SSL connection
-      alias_method :connect_with_timeout, :connect_ssl
+      def connect_ssl
+        socket.connect_nonblock
+      rescue IO::WaitReadable
+        if IO.select([socket], nil, nil, connect_timeout)
+          retry
+        else
+          raise TimeoutError, "Connection timed out after #{connect_timeout} seconds"
+        end
+      end
 
       # Read data from the socket
       def readpartial(size)
@@ -75,43 +54,6 @@ module HTTP
           raise TimeoutError, "Read timed out after #{write_timeout} seconds"
         end
       end
-
-      private
-
-      # Actually do the connect after we're setup
-      def connect_with_timeout(*args)
-        socket.connect_nonblock(*args)
-
-      rescue IO::WaitReadable
-        if IO.select([socket], nil, nil, connect_timeout)
-          retry
-        else
-          raise TimeoutError, "Connection timed out after #{connect_timeout} seconds"
-        end
-
-      rescue Errno::EINPROGRESS
-        if IO.select(nil, [socket], nil, connect_timeout)
-          retry
-        else
-          raise TimeoutError, "Connection timed out after #{connect_timeout} seconds"
-        end
-
-      rescue Errno::EISCONN
-      end
-
-      # Create a DNS resolver
-      def resolve_address(host)
-        addr = HostResolver.getaddress(host)
-        return addr if addr
-
-        Resolv::DNS.open(:timeout => connect_timeout) do |dns|
-          dns.getaddress
-        end
-
-      rescue Resolv::ResolvTimeout
-        raise TimeoutError, "DNS timed out after #{connect_timeout} seconds"
-      end
     end
   end
 end
-# rubocop:enable Lint/HandleExceptions

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe HTTP::Client do
       described_class.new options.merge :ssl_context => SSLHelper.client_context
     end
 
-    include_context "HTTP handling", true do
+    include_context "HTTP handling" do
       let(:server) { dummy_ssl }
     end
 


### PR DESCRIPTION
Unfortunately, getting a pure solution to timeouts is essentially impossible without rewriting the entire stack yourself. Which I might actually do for fun later, but for the time being. This is the simplest way of getting a connect timeout :(