### PR TITLE
Make sure we catch WaitWritable for SSL

### DIFF
--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -28,6 +28,10 @@ module HTTP
           IO.select([socket], nil, nil, time_left)
           log_time
           retry
+        rescue IO::WaitWritable
+          IO.select(nil, [socket], nil, time_left)
+          log_time
+          retry
         end
       end
 

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -31,6 +31,12 @@ module HTTP
         else
           raise TimeoutError, "Connection timed out after #{connect_timeout} seconds"
         end
+      rescue IO::WaitWritable
+        if IO.select(nil, [socket], nil, connect_timeout)
+          retry
+        else
+          raise TimeoutError, "Connection timed out after #{connect_timeout} seconds"
+        end
       end
 
       # Read data from the socket


### PR DESCRIPTION
@tarcieri going to merge on green just as a fyi

Looking at Excon's code, they only time they don't raise is on `read will block` and not on writes (until my change) where I technically broke it.

I'm still going to add this as a just in case, since the Ruby docs mention it. 