### PR TITLE
Automatically use non-exception NIOs for improved performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   CountComments: false
-  Max: 120
+  Max: 125
 
 Metrics/PerceivedComplexity:
   Max: 8

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -35,29 +35,65 @@ module HTTP
         end
       end
 
-      # Read from the socket
-      def readpartial(size)
-        reset_timer
+      # NIO with exceptions
+      if RUBY_VERSION < "2.1.0"
+        # Read from the socket
+        def readpartial(size)
+          reset_timer
 
-        begin
-          socket.read_nonblock(size)
-        rescue IO::WaitReadable
-          IO.select([socket], nil, nil, time_left)
-          log_time
-          retry
+          begin
+            socket.read_nonblock(size)
+          rescue IO::WaitReadable
+            IO.select([socket], nil, nil, time_left)
+            log_time
+            retry
+          end
+        rescue EOFError
+          :eof
         end
-      end
 
-      # Write to the socket
-      def write(data)
-        reset_timer
+        # Write to the socket
+        def write(data)
+          reset_timer
 
-        begin
-          socket << data
-        rescue IO::WaitWritable
-          IO.select(nil, [socket], nil, time_left)
-          log_time
-          retry
+          begin
+            socket.write_nonblock(data)
+          rescue IO::WaitWritable
+            IO.select(nil, [socket], nil, time_left)
+            log_time
+            retry
+          end
+        rescue EOFError
+          :eof
+        end
+
+      # NIO without exceptions
+      else
+
+        # Read from the socket
+        def readpartial(size)
+          reset_timer
+
+          loop do
+            result = socket.read_nonblock(size, :exception => false)
+            break result unless result == :wait_readable
+
+            IO.select([socket], nil, nil, time_left)
+            log_time
+          end
+        end
+
+        # Write to the socket
+        def write(data)
+          reset_timer
+
+          loop do
+            result = socket.write_nonblock(data, :exception => false)
+            break unless result == :wait_writable
+
+            IO.select(nil, [socket], nil, time_left)
+            log_time
+          end
         end
       end
 


### PR DESCRIPTION
Here's a fun one. Apparently, in 2.1.x (and as such, JRuby 9k), Ruby added an undocumented arg to the NIO methods that allows you to use them without exceptions and instead symbol returns of the results. This is only available for write/read and not connect.

Quick performance test of `read_nonblock` with and without exceptions. On MRI, without exceptions is 50% faster, on JRuby it's around 85% faster. This is about inline with what we expect, exceptions in Java/JRuby are much more costly than Ruby, which are already costly.

The problem like everything, is testing it is a bitch :(


cc @tarcieri @nerdrew