### PR TITLE
Updated documentation on timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,16 +253,6 @@ There's a little more to it, but that's the core idea!
 * [Full parallel HTTP fetcher example](https://github.com/httprb/http.rb/wiki/Parallel-requests-with-Celluloid%3A%3AIO)
 * See also: [Celluloid::IO](https://github.com/celluloid/celluloid-io)
 
-
-#### WARNING
-
-Celluloid support [was broken][issue-203] with `0.8.0` release.
-For Celluloid support use `0.7` for now.
-
-
-[issue-203]: https://github.com/httprb/http.rb/issues/203
-
-
 ### Caching
 
 http.rb provides caching of HTTP request (per
@@ -287,12 +277,23 @@ storage URL supported by rack-cache is supported by http.rb's cache.
 
 ### Timeouts
 
-You can configure http.rb to fail if request (connect / read / write) takes too
-long:
+By default, HTTP does not timeout on a request. You can enable per operation (each read/write/connect call) or global (sum of all read/write/connect calls).
+
+Per operation timeouts are what `Net::HTTP` and the majority of HTTP clients do:
 
 ``` ruby
-HTTP.timeout(:connect => 5, :read => 10).get "http://example.com"
+HTTP.timeout(:per_operation, :write => 2, :connect => 5, :read => 10).get "http://example.com"
 ```
+
+Global timeouts let you set an upper bound of how long a request can take, without having to rely on `Timeout.timeout`:
+
+``` ruby
+HTTP.timeout(:global, :write => 1, :connect => 1, :read => 1).get "http://example.com"
+```
+
+Uses a timeout of 3 seconds, for the entire `get` call.
+
+*Warning!* You cannot use Celluloid::IO with timeouts currently.
 
 
 ## Supported Ruby Versions


### PR DESCRIPTION
@ixti the docs on timeout aren't quite right (namely they need the type of timeout). Celluloid::IO works again, since the `respond_to? :sync_close=` change was made. Although @tarcieri should tag a new celluloid-io that has that fix in!