### PR TITLE
Make sure port number isn't blank for proxy connect

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -132,7 +132,7 @@ module HTTP
 
     # Compute HTTP request header SSL proxy connection
     def proxy_connect_header
-      "CONNECT #{@uri.host}:#{@uri.port} HTTP/#{version}"
+      "CONNECT #{host}:#{port} HTTP/#{version}"
     end
 
     # Headers to send with proxy connect request


### PR DESCRIPTION
I think this fixes #217 the problem seemed to be that @uri.port was blank so a port wasn't being specified if the default port was used. Seems like this code should be using the helper methods anyway.