### PR TITLE
Force encoding to be consistent.

### DIFF
--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -36,9 +36,9 @@ module HTTP
 
         begin
           @streaming = false
-          @contents = ""
+          @contents = "".force_encoding(Encoding::UTF_8)
           while (chunk = @client.readpartial)
-            @contents << chunk
+            @contents << chunk.force_encoding(Encoding::ASCII_8BIT)
           end
         rescue
           @contents = nil

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -131,6 +131,20 @@ RSpec.describe HTTP do
     end
   end
 
+  context "loading binary data" do
+    it "is encoded as bytes" do
+      response = HTTP.get "#{dummy.endpoint}/bytes"
+      expect(response.to_s.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+  end
+
+  context "loading text" do
+    it "is utf-8 encoded" do
+      response = HTTP.get dummy.endpoint
+      expect(response.to_s.encoding).to eq(Encoding::UTF_8)
+    end
+  end
+
   context "posting with an explicit body" do
     it "is easy" do
       response = HTTP.post "#{dummy.endpoint}/body", :body => "testing-body"

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -122,5 +122,11 @@ class DummyServer < WEBrick::HTTPServer
       res.status          = 200
       res["Content-Type"] = "text/html"
     end
+
+    get "/bytes" do |_req, res|
+      bytes = [80, 75, 3, 4, 20, 0, 0, 0, 8, 0, 123, 104, 169, 70, 99, 243, 243]
+      res["Content-Type"] = "application/octet-stream"
+      res.body = bytes.pack("c*")
+    end
   end
 end


### PR DESCRIPTION
Loading binary data through http.rb in jruby returns a utf-8 encoded string right now, which then errors if invalid utf-8 sequences are included.

Not sure if this is the right solution, but it fixes my problem and makes the encodings of returned data consistent across ruby versions.