### PR TITLE
a DRY change, addressing code duplication in http/timeout/per_operation

### DIFF
--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -66,7 +66,7 @@ module HTTP
         if IO.select(nil, [socket], nil, write_timeout)
           retry
         else
-          raise TimeoutError, "Read timed out after #{write_timeout} seconds"
+          raise TimeoutError, "Write timed out after #{write_timeout} seconds"
         end
       end
     end

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -45,9 +45,11 @@ module HTTP
       def write(data)
         @socket << data
       end
+      alias_method :<<, :write
 
+      private
       # Retry reading
-      def __rescue_readable
+      def rescue_readable
         yield
       rescue IO::WaitReadable
         if IO.select([socket], nil, nil, read_timeout)
@@ -58,7 +60,7 @@ module HTTP
       end
 
       # Retry writing
-      def __rescue_writable
+      def rescue_writable
         yield
       rescue IO::WaitWritable
         if IO.select(nil, [socket], nil, write_timeout)
@@ -67,8 +69,6 @@ module HTTP
           raise TimeoutError, "Read timed out after #{write_timeout} seconds"
         end
       end
-
-      alias_method :<<, :write
     end
   end
 end

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -47,7 +47,7 @@ module HTTP
       end
 
       # Retry reading
-      def __rescue_readable(&block)
+      def __rescue_readable
         yield
       rescue IO::WaitReadable
         if IO.select([socket], nil, nil, read_timeout)
@@ -58,7 +58,7 @@ module HTTP
       end
 
       # Retry writing
-      def __rescue_writable(&block)
+      def __rescue_writable
         yield
       rescue IO::WaitWritable
         if IO.select(nil, [socket], nil, write_timeout)

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -46,6 +46,28 @@ module HTTP
         @socket << data
       end
 
+      # Retry reading
+      def __rescue_readable(&block)
+        yield
+      rescue IO::WaitReadable
+        if IO.select([socket], nil, nil, read_timeout)
+          retry
+        else
+          raise TimeoutError, "Read timed out after #{read_timeout} seconds"
+        end
+      end
+
+      # Retry writing
+      def __rescue_writable(&block)
+        yield
+      rescue IO::WaitWritable
+        if IO.select(nil, [socket], nil, write_timeout)
+          retry
+        else
+          raise TimeoutError, "Read timed out after #{write_timeout} seconds"
+        end
+      end
+
       alias_method :<<, :write
     end
   end

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -22,40 +22,24 @@ module HTTP
       end
 
       def connect_ssl
-        socket.connect_nonblock
-      rescue IO::WaitReadable
-        if IO.select([socket], nil, nil, connect_timeout)
-          retry
-        else
-          raise TimeoutError, "Connection timed out after #{connect_timeout} seconds"
-        end
-      rescue IO::WaitWritable
-        if IO.select(nil, [socket], nil, connect_timeout)
-          retry
-        else
-          raise TimeoutError, "Connection timed out after #{connect_timeout} seconds"
+        __rescue_readable do
+          __rescue_writable do
+            socket.connect_nonblock
+          end
         end
       end
 
       # Read data from the socket
       def readpartial(size)
-        socket.read_nonblock(size)
-      rescue IO::WaitReadable
-        if IO.select([socket], nil, nil, read_timeout)
-          retry
-        else
-          raise TimeoutError, "Read timed out after #{read_timeout} seconds"
+        __rescue_readable do
+          socket.read_nonblock(size)
         end
       end
 
       # Write data to the socket
       def write(data)
-        socket.write_nonblock(data)
-      rescue IO::WaitWritable
-        if IO.select(nil, [socket], nil, write_timeout)
-          retry
-        else
-          raise TimeoutError, "Read timed out after #{write_timeout} seconds"
+        __rescue_writable do
+          socket.write_nonblock(data)
         end
       end
     end

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -22,8 +22,8 @@ module HTTP
       end
 
       def connect_ssl
-        __rescue_readable do
-          __rescue_writable do
+        rescue_readable do
+          rescue_writable do
             socket.connect_nonblock
           end
         end
@@ -31,14 +31,14 @@ module HTTP
 
       # Read data from the socket
       def readpartial(size)
-        __rescue_readable do
+        rescue_readable do
           socket.read_nonblock(size)
         end
       end
 
       # Write data to the socket
       def write(data)
-        __rescue_writable do
+        rescue_writable do
           socket.write_nonblock(data)
         end
       end


### PR DESCRIPTION
CodeClimate highlighted some duplication in the Timeout::PerOperation class. This change eliminates the code duplication.